### PR TITLE
Notify-OSD append support

### DIFF
--- a/npapi/LinuxNativeNotificationAPI.cpp
+++ b/npapi/LinuxNativeNotificationAPI.cpp
@@ -77,7 +77,13 @@ FB::variant LinuxNativeNotificationAPI::notify(const FB::variant& summary,
                                                          str_body.c_str(),
                                                          "/tmp/linuxnativenotification_image");
 
-    if(notify_notification_show(pnote, NULL) == FALSE)
+   // Try to append the notification
+   if (str_summary == m_previous_summary)
+      notify_notification_set_hint_string (pnote, "x-canonical-append", "true");
+
+    m_previous_summary = str_summary;
+
+    if (notify_notification_show(pnote, NULL) == FALSE)
         return FB::variant(false);
 
     return FB::variant(true);

--- a/npapi/LinuxNativeNotificationAPI.h
+++ b/npapi/LinuxNativeNotificationAPI.h
@@ -62,6 +62,7 @@ private:
     FB::BrowserHostPtr m_host;
 
     std::string m_testString;
+    std::string m_previous_summary;
 };
 
 #endif // H_LinuxNativeNotificationAPI


### PR DESCRIPTION
Try to append notifications if the summary matches

When the previous recorded notification has the same summary of the current one, we try to append it to the previous one, using the notify-osd append protocol. This will work only if the notification system used supports this feature.

My first version of this was also checking for unchanged icon path, however this would cause the google talk notifications not to work correctly, since the icon changes the URI slightly at every message (due to a different session key), so I removed it. However it should be safe anyway for most cases.

Of course if the notification system doesn't support this protocol, nothing will change.

Demo: http://go.3v1n0.net/JRZGN2 
